### PR TITLE
Improve rendering with SSR

### DIFF
--- a/src/components/Icon.svelte
+++ b/src/components/Icon.svelte
@@ -162,11 +162,9 @@
     return `${combined}font-size: ${size}em`;
   }
 
-  afterUpdate(() => {
-    init();
-    width = calculateWidth();
-    height = calculateHeight();
-    combinedStyle = calculateStyle();
-    box = calculateBox();
-  });
+  init();
+  width = calculateWidth();
+  height = calculateHeight();
+  combinedStyle = calculateStyle();
+  box = calculateBox();
 </script>

--- a/src/components/svg/Path.svelte
+++ b/src/components/svg/Path.svelte
@@ -1,18 +1,6 @@
-<path key="path-{id}" bind:this={path} />
+<path key="path-{id}" {...data} />
 
 <script>
-  import { afterUpdate } from 'svelte';
-
-  let path;
-
   export let id = '';
   export let data = {};
-
-  afterUpdate(() => {
-    if (typeof path !== 'undefined') {
-      Object.keys(data).forEach((key) => {
-        path.setAttribute(key, data[key]);
-      });
-    }
-  });
 </script>

--- a/src/components/svg/Polygon.svelte
+++ b/src/components/svg/Polygon.svelte
@@ -1,18 +1,6 @@
-<polygon key="polygon-{id}" bind:this={polygon} />
+<polygon key="polygon-{id}" {...data} />
 
 <script>
-  import { afterUpdate } from 'svelte';
-
-  let polygon;
-
   export let id = '';
   export let data = {};
-
-  afterUpdate(() => {
-    if (typeof polygon !== 'undefined') {
-      Object.keys(data).forEach((key) => {
-        polygon.setAttribute(key, data[key]);
-      });
-    }
-  });
 </script>

--- a/src/components/svg/Raw.svelte
+++ b/src/components/svg/Raw.svelte
@@ -4,8 +4,6 @@
 
 <script>
   /* eslint-disable no-unused-vars, import/prefer-default-export */
-  import { afterUpdate } from 'svelte';
-
   let cursor = 0xd4937;
   function getId() {
     cursor += 1;
@@ -16,7 +14,7 @@
 
   export let data;
 
-  function getRaw() {
+  function getRaw(data) {
     if (!data || !data.raw) {
       return null;
     }
@@ -38,7 +36,5 @@
     return rawData;
   }
 
-  afterUpdate(() => {
-    raw = getRaw();
-  });
+  $: raw = getRaw(data);
 </script>

--- a/src/components/svg/Svg.svelte
+++ b/src/components/svg/Svg.svelte
@@ -1,9 +1,11 @@
-<svg version="1.1" bind:this={svg} class="fa-icon {className}"
+<svg version="1.1" class="fa-icon {className}"
   class:fa-spin={spin} class:fa-pulse={pulse} class:fa-inverse={inverse}
   class:fa-flip-horizontal="{flip === 'horizontal'}" class:fa-flip-vertical="{flip === 'vertical'}"
-  width={width} height={height}
+  {x} {y} {width} {height}
+  aria-label={label}
   role="{ label ? 'img' : 'presentation' }"
-  viewBox={box} style={style}>
+  viewBox={box} style={style}
+  >
   <slot></slot>
 </svg>
 
@@ -38,9 +40,6 @@
 </style>
 
 <script>
-  import { afterUpdate } from 'svelte';
-
-  let svg;
   let className;
 
   export { className as class };
@@ -55,25 +54,8 @@
   export let flip = null;
 
   // optionals
-  export let x = false;
-  export let y = false;
-  export let style = null;
-  export let label = false;
-
-  afterUpdate(() => {
-    if (typeof svg !== 'undefined') {
-      if (x) {
-        svg.setAttribute('x', x);
-      }
-      if (y) {
-        svg.setAttribute('y', y);
-      }
-      if (style) {
-        svg.setAttribute('style', style);
-      }
-      if (label) {
-        svg.setAttribute('aria-label', label);
-      }
-    }
-  });
+  export let x = undefined;
+  export let y = undefined;
+  export let style = undefined;
+  export let label = undefined;
 </script>


### PR DESCRIPTION
Fixes #506 . First, it's important to mention that I've only tested this with path-based SVG icons, since I'm not sure which icons use polygon or raw data. Please give it a quick try with icons of those types to make sure I didn't screw everything up.

The issue with running in SSR is that afterUpdate and related methods don't run on the server, so the component wasn't initializing until we got to the client. Fortunately it appears that it wasn't actually necessary in any of these cases.

Quick overview of the changes:

1.  I replaced all the Object.keys(data).forEach(...) cases with just {...data} on the component tag which has the same effect but doesn't require the component to be mounted first.
2. Raw component: I replaced afterUpdate with a reactive call to getRaw.
3. Svg component: I changed the optional properties to default to undefined and then just applied them directly to the component using the {x} syntax.

With these changes, SSR renders the Icon component properly so the width/height/etc. are set correctly and the svg element is populated.

Finally, thanks for this great library. It's great to be able to just do pulse or similar and have the icon animate.