### PR TITLE
fix: #187 remove non-unique ids from `path` and `polygon`

### DIFF
--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -3,13 +3,13 @@
   <slot>
     {#if self}
       {#if self.paths}
-        {#each self.paths as path, i}
-        <Path id="{i}" data="{path}"/>
+        {#each self.paths as path}
+        <Path data="{path}"/>
         {/each}
       {/if}
       {#if self.polygons}
-        {#each self.polygons as polygon, i}
-        <Polygon id="{i}" data="{polygon}"/>
+        {#each self.polygons as polygon}
+        <Polygon data="{polygon}"/>
         {/each}
       {/if}
       {#if self.raw}

--- a/src/lib/components/svg/Path.svelte
+++ b/src/lib/components/svg/Path.svelte
@@ -1,6 +1,5 @@
-<path id="path-{id}" {...data} />
+<path {...data} />
 
 <script lang="ts">
-  export let id: number;
   export let data = {};
 </script>

--- a/src/lib/components/svg/Polygon.svelte
+++ b/src/lib/components/svg/Polygon.svelte
@@ -1,6 +1,5 @@
-<polygon id="polygon-{id}" {...data} />
+<polygon {...data} />
 
 <script lang="ts">
-  export let id: number;
   export let data = {};
 </script>


### PR DESCRIPTION
Fixes #187. I think the ids are redundant and can be removed, solving the issue of duplicate ids