### PR TITLE
Add svelte options tag to fix rendering in Svelte 5

### DIFF
--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -1,4 +1,3 @@
-<svelte:options namespace='svg'/>
 <Svg
   {label}
   {width}
@@ -205,3 +204,5 @@
     box = calculateBox();
   }
 </script>
+
+<svelte:options namespace="svg" />

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -1,3 +1,4 @@
+<svelte:options namespace='svg'/>
 <Svg
   {label}
   {width}


### PR DESCRIPTION
Svelte 5 appears to require the addition of `<svelte:options namespace='svg'/>` in `Icon.svelte` in order to render the SVG. 

Related issue: https://github.com/RobBrazier/svelte-awesome/issues/1059

<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/RobBrazier/svelte-awesome/pull/1060)
<!-- GitContextEnd -->